### PR TITLE
Add CI for pulling charts from GH releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  lint-scripts:
+  lint:
     docker:
-      - image: giantswarm/shellcheck-alpine:v0.6.0
+      - image: quay.io/giantswarm/shellcheck-alpine:v0.6.0
     steps:
       - checkout
       - run:
@@ -21,10 +21,8 @@ workflows:
   version: 2
   lint-sync:
     jobs:
-      - lint-scripts
-      - sync:
-          requires:
-            - lint-scripts
+      - lint
+      - sync
   sync:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  lint-scripts:
+    docker:
+      - image: giantswarm/shellcheck-alpine:v0.6.0
+    steps:
+      - checkout
+      - run:
+          name: lint scripts
+          command: shellcheck -x ci-scripts/*
+  sync:
+    machine: true
+    steps:
+    - checkout
+
+    - run:
+        name: Fetch new app releases and rebuild helm chart repository
+        command: ci-scripts/build-repository.sh ${CIRCLE_PROJECT_REPONAME} ${PERSONAL_ACCESS_TOKEN}
+
+workflows:
+  version: 2
+  lint-sync:
+    jobs:
+      - lint-scripts
+      - sync:
+          requires:
+            - lint-scripts
+  sync:
+    triggers:
+      - schedule:
+          cron: "10,25,40,55 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - sync

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,9 @@ jobs:
 
 workflows:
   version: 2
-  lint-sync:
+  lint:
     jobs:
       - lint
-      - sync
   sync:
     triggers:
       - schedule:

--- a/APPS
+++ b/APPS
@@ -1,0 +1,1 @@
+giantswarm/prometheus

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![CircleCI](https://circleci.com/gh/giantswarm/app-catalog.svg?style=svg)](https://circleci.com/gh/giantswarm/app-catalog)
 # app-catalog

--- a/ci-scripts/build-repository.sh
+++ b/ci-scripts/build-repository.sh
@@ -9,7 +9,7 @@ readonly PERSONAL_ACCESS_TOKEN=$2
 
 readonly APPS_FILE=./APPS
 readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
-readonly HELM_TARBALL=helm-v2.11.0-linux-amd64.tar.gz
+readonly HELM_TARBALL=helm-v2.12.0-linux-amd64.tar.gz
 readonly HELM_REPO_URL=https://giantswarm.github.com/${REPONAME}
 
 main() {

--- a/ci-scripts/build-repository.sh
+++ b/ci-scripts/build-repository.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly REPONAME=$1
+readonly PERSONAL_ACCESS_TOKEN=$2
+
+readonly APPS_FILE=./APPS
+readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
+readonly HELM_TARBALL=helm-v2.11.0-linux-amd64.tar.gz
+readonly HELM_REPO_URL=https://giantswarm.github.com/${REPONAME}
+
+main() {
+    setup_helm_client
+
+    if ! download_latest_charts; then
+        log_error "Not all charts could be downloaded!"
+    fi
+
+    if ! sync_repo "${HELM_REPO_URL}"; then
+        log_error "Not all charts could be packaged and synced!"
+    fi
+
+    cleanup
+}
+
+cleanup() {
+  rm -rf sync linux-amd64 ${HELM_TARBALL}
+}
+
+setup_helm_client() {
+    echo "Setting up Helm client..."
+
+    curl --user-agent curl-ci-sync -sSL -o "${HELM_TARBALL}" "${HELM_URL}/${HELM_TARBALL}"
+    tar xzfv "${HELM_TARBALL}"
+
+    PATH="$(pwd)/linux-amd64/:$PATH"
+
+    helm init --client-only
+    helm repo add "${REPONAME}" "${HELM_REPO_URL}"
+}
+
+download_latest_charts() {
+  while IFS="" read -r app || [ -n "${app}" ]
+  do
+      release_url=$(curl -s "https://api.github.com/repos/${app}/releases/latest" | jq -r .assets[0].browser_download_url)
+      chart=$(echo "${release_url}" | tr "/" " " | awk '{print $NF}')
+
+      # Check if release exists and not already present
+      if [ "${release_url}" == "null" ];then
+        echo "No GitHub release of '${app}' found!"
+        exit 1
+      elif [ -e "${chart}" ];then
+        echo "${chart} already present, skipping!"
+      else
+        echo "Downloading chart '${chart}'..."
+        wget -q -P sync "${release_url}"
+      fi
+  done < ${APPS_FILE}
+}
+
+sync_repo() {
+    local repo_url="${1?Specify repo url}"
+
+    if [ ! -d "sync" ]; then
+      echo "No new releases found. Terminating"
+      return 0
+    fi
+
+    echo "Syncing repo..."
+    if helm repo index --url "${repo_url}" --merge "index.yaml" "sync"; then
+        mv -f ./sync/* .
+
+        git add ./*.tgz
+        git add index.yaml
+
+        git -c user.name="Taylor Bot" -c user.email="dev@giantswarm.io" commit -m "Auto build: ${REPONAME}"
+        git push -q "https://${PERSONAL_ACCESS_TOKEN}@github.com/giantswarm/${REPONAME}.git" master
+    else
+        log_error "Exiting because unable to update index. Not safe to push update."
+        exit 1
+    fi
+    return 0
+}
+
+log_error() {
+    printf '\e[31mERROR: %s\n\e[39m' "$1" >&2
+}
+
+main

--- a/ci-scripts/build-repository.sh
+++ b/ci-scripts/build-repository.sh
@@ -25,8 +25,6 @@ main() {
     if ! sync_repo "${HELM_REPO_URL}"; then
         log_error "Not all charts could be packaged and synced!"
     fi
-
-    cleanup
 }
 
 setup_helm_client() {
@@ -83,11 +81,6 @@ sync_repo() {
     fi
     return 0
 }
-
-cleanup() {
-  rm -rf sync linux-amd64 ${HELM_TARBALL}
-}
-
 
 log_error() {
     printf '\e[31mERROR: %s\n\e[39m' "$1" >&2

--- a/ci-scripts/build-repository.sh
+++ b/ci-scripts/build-repository.sh
@@ -13,7 +13,10 @@ readonly HELM_TARBALL=helm-v2.11.0-linux-amd64.tar.gz
 readonly HELM_REPO_URL=https://giantswarm.github.com/${REPONAME}
 
 main() {
-    setup_helm_client
+    if ! setup_helm_client; then
+      log_error "Helm client could not get installed."
+      exit 1
+    fi
 
     if ! download_latest_charts; then
         log_error "Not all charts could be downloaded!"

--- a/ci-scripts/build-repository.sh
+++ b/ci-scripts/build-repository.sh
@@ -29,10 +29,6 @@ main() {
     cleanup
 }
 
-cleanup() {
-  rm -rf sync linux-amd64 ${HELM_TARBALL}
-}
-
 setup_helm_client() {
     echo "Setting up Helm client..."
 
@@ -87,6 +83,11 @@ sync_repo() {
     fi
     return 0
 }
+
+cleanup() {
+  rm -rf sync linux-amd64 ${HELM_TARBALL}
+}
+
 
 log_error() {
     printf '\e[31mERROR: %s\n\e[39m' "$1" >&2


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4848.
Dependend on https://github.com/giantswarm/prometheus/pull/112.

Adds CI that publishes charts to the the hosted helm repostiory (https://giantswarm.github.io/app-catalog/). The chart tarballs are pulled from GH releases from apps that are specified in the `APP` file.

- The `ci-scripts/build-repo.sh` is based on the upstream CI script: https://github.com/helm/charts/blob/master/test/repo-sync.sh
(Do we need to include APACHE licencse here too then btw?)
- You can read up about the upstream helm repositories wer are using here: https://github.com/helm/helm/blob/master/docs/chart_repository.md
- TL;DR: The helm charts are hosted on this repo, which is published with GitHub Pages

Notes:
- This script-based solution is to have a first working app-catalog out there soon. Considerations about moving it to either GitHub Actions, CircleCI Orbs or integrate into our tooling (e.g. architect, devctl) should be taken in the future.
- **Caution:** The Circle Cronjob is set up to run every 15 Minutes. If multiple versions of one App are relased within the 15 minute interval, only the latest will get published. We should consider changing this in the future.