### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -63,7 +63,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-enforcer-5.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-enforcer-5.3.0.tgz
     version: 5.3.0
   - apiVersion: v1
     appVersion: 4.6.0
@@ -76,7 +76,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-enforcer-4.6.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-enforcer-4.6.3.tgz
     version: 4.6.3
   - apiVersion: v1
     appVersion: 4.6.0
@@ -89,7 +89,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-enforcer-4.6.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-enforcer-4.6.2.tgz
     version: 4.6.2
   - apiVersion: v1
     appVersion: 4.6.0
@@ -102,7 +102,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-enforcer-4.6.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-enforcer-4.6.1.tgz
     version: 4.6.1
   - apiVersion: v1
     appVersion: 4.6.0
@@ -115,7 +115,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-enforcer-4.6.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-enforcer-4.6.0.tgz
     version: 4.6.0
   - apiVersion: v1
     appVersion: 4.5.0
@@ -128,7 +128,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-enforcer-0.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-enforcer-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
     appVersion: 4.5.0
@@ -141,7 +141,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-enforcer-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-enforcer-0.2.0.tgz
     version: 0.2.0
   aqua-app-scanner:
   - annotations:
@@ -206,7 +206,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-scanner-5.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-scanner-5.3.0.tgz
     version: 5.3.0
   - apiVersion: v1
     appVersion: 4.6.0
@@ -219,7 +219,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-scanner-4.6.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-scanner-4.6.3.tgz
     version: 4.6.3
   - apiVersion: v1
     appVersion: 4.6.0
@@ -232,7 +232,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-scanner-4.6.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-scanner-4.6.2.tgz
     version: 4.6.2
   - apiVersion: v1
     appVersion: 4.6.0
@@ -245,7 +245,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-scanner-4.6.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-scanner-4.6.1.tgz
     version: 4.6.1
   - apiVersion: v1
     appVersion: 4.6.0
@@ -258,7 +258,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-scanner-4.6.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-scanner-4.6.0.tgz
     version: 4.6.0
   - apiVersion: v1
     appVersion: 4.5.0
@@ -271,7 +271,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-scanner-0.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-scanner-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
     appVersion: 4.5.0
@@ -284,7 +284,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-scanner-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-scanner-0.2.0.tgz
     version: 0.2.0
   aqua-app-server:
   - annotations:
@@ -349,7 +349,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-server-5.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-server-5.3.0.tgz
     version: 5.3.0
   - apiVersion: v1
     appVersion: 4.6.0
@@ -362,7 +362,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-server-4.6.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-server-4.6.3.tgz
     version: 4.6.3
   - apiVersion: v1
     appVersion: 4.6.0
@@ -375,7 +375,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-server-4.6.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-server-4.6.2.tgz
     version: 4.6.2
   - apiVersion: v1
     appVersion: 4.6.0
@@ -388,7 +388,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-server-4.6.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-server-4.6.1.tgz
     version: 4.6.1
   - apiVersion: v1
     appVersion: 4.6.0
@@ -401,7 +401,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-server-4.6.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-server-4.6.0.tgz
     version: 4.6.0
   - apiVersion: v1
     appVersion: 4.5.0
@@ -414,7 +414,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-server-0.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-server-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
     appVersion: 4.5.0
@@ -427,7 +427,7 @@ entries:
     sources:
     - https://github.com/aquasecurity/aqua-helm
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/aqua-app-server-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/aqua-app-server-0.2.0.tgz
     version: 0.2.0
   calico:
   - apiVersion: v1
@@ -440,7 +440,7 @@ entries:
     sources:
     - https://github.com/projectcalico/calico
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/calico-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/calico-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
     appVersion: 3.18.0
@@ -452,7 +452,7 @@ entries:
     sources:
     - https://github.com/projectcalico/calico
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/calico-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/calico-0.1.0.tgz
     version: 0.1.0
   cert-manager-app:
   - annotations:
@@ -506,7 +506,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.4.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.4.2.tgz
     version: 2.4.2
   - annotations:
       application.giantswarm.io/readme: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v2.4.1/README.md
@@ -522,7 +522,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.4.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.4.1.tgz
     version: 2.4.1
   - annotations:
       application.giantswarm.io/readme: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v2.4.0/README.md
@@ -538,7 +538,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.4.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.4.0.tgz
     version: 2.4.0
   - annotations:
       application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v2.3.3/helm/cert-manager-app/values.schema.json
@@ -553,7 +553,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.3.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.3.3.tgz
     version: 2.3.3
   - annotations:
       application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/cert-manager-app/v2.3.2/helm/cert-manager-app/values.schema.json
@@ -568,7 +568,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.3.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.3.2.tgz
     version: 2.3.2
   - apiVersion: v1
     appVersion: 1.0.2
@@ -581,7 +581,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.3.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.3.1.tgz
     version: 2.3.1
   - apiVersion: v1
     appVersion: 1.0.2
@@ -594,7 +594,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.3.0.tgz
     version: 2.3.0
   - apiVersion: v1
     appVersion: 0.16.1
@@ -607,7 +607,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.2.5.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.2.5.tgz
     version: 2.2.5
   - apiVersion: v1
     appVersion: 0.16.1
@@ -620,7 +620,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.2.4.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.2.4.tgz
     version: 2.2.4
   - apiVersion: v1
     appVersion: 0.16.1
@@ -633,7 +633,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.1.4.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.1.4.tgz
     version: 2.1.4
   - apiVersion: v1
     appVersion: 0.16.1
@@ -646,7 +646,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.1.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.1.3.tgz
     version: 2.1.3
   - apiVersion: v1
     appVersion: 0.16.1
@@ -659,7 +659,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.1.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.1.2.tgz
     version: 2.1.2
   - apiVersion: v1
     appVersion: 0.16.1
@@ -672,7 +672,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.1.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.1.1.tgz
     version: 2.1.1
   - apiVersion: v1
     appVersion: 0.16.1
@@ -685,7 +685,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.1.0.tgz
     version: 2.1.0
   - apiVersion: v1
     appVersion: 0.15.2
@@ -698,7 +698,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.0.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.0.2.tgz
     version: 2.0.2
   - apiVersion: v1
     appVersion: 0.15.2
@@ -711,7 +711,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.0.1.tgz
     version: 2.0.1
   - apiVersion: v1
     appVersion: 0.15.2
@@ -724,7 +724,7 @@ entries:
     sources:
     - https://github.com/jetstack/cert-manager
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-2.0.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-2.0.0.tgz
     version: 2.0.0
   - apiVersion: v1
     appVersion: 0.9.0
@@ -735,7 +735,7 @@ entries:
     icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
     name: cert-manager-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-1.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-1.1.0.tgz
     version: 1.1.0
   - apiVersion: v1
     appVersion: 0.9.0
@@ -746,7 +746,7 @@ entries:
     icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
     name: cert-manager-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-1.0.8.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-1.0.8.tgz
     version: 1.0.8
   - apiVersion: v1
     appVersion: 0.9.0
@@ -757,7 +757,7 @@ entries:
     icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
     name: cert-manager-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-1.0.7.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-1.0.7.tgz
     version: 1.0.7
   - apiVersion: v1
     appVersion: 0.9.0
@@ -768,7 +768,7 @@ entries:
     icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
     name: cert-manager-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-1.0.6.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-1.0.6.tgz
     version: 1.0.6
   - apiVersion: v1
     appVersion: 0.9.0
@@ -777,7 +777,7 @@ entries:
     digest: 32d15548733b2bd2ffd7a4b8e5417d2a58f8e5be6ec74f6855291026b1ac9b49
     name: cert-manager-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-1.0.5.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-1.0.5.tgz
     version: 1.0.5
   - apiVersion: v1
     appVersion: 0.9.0
@@ -787,7 +787,7 @@ entries:
     home: https://github.com/jetstack/cert-manager
     name: cert-manager-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-1.0.4.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-1.0.4.tgz
     version: 1.0.4
   - apiVersion: v1
     appVersion: 0.9.0
@@ -797,7 +797,7 @@ entries:
     home: https://github.com/jetstack/cert-manager
     name: cert-manager-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-1.0.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-1.0.3.tgz
     version: 1.0.3
   - apiVersion: v1
     appVersion: 0.9.0
@@ -807,7 +807,7 @@ entries:
     home: https://github.com/jetstack/cert-manager
     name: cert-manager-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-1.0.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-1.0.2.tgz
     version: 1.0.2
   - apiVersion: v1
     appVersion: 0.9.0
@@ -817,7 +817,7 @@ entries:
     home: https://github.com/jetstack/cert-manager
     name: cert-manager-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cert-manager-app-1.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cert-manager-app-1.0.1.tgz
     version: 1.0.1
   cloudflared:
   - annotations:
@@ -835,7 +835,7 @@ entries:
     sources:
     - https://github.com/giantswarm/cloudflared-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cloudflared-0.0.5.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cloudflared-0.0.5.tgz
     version: 0.0.5
   - annotations:
       application.giantswarm.io/metadata: https://giantswarm.github.io/giantswarm-catalog/cloudflared-0.0.4.tgz-meta/main.yaml
@@ -852,7 +852,7 @@ entries:
     sources:
     - https://github.com/giantswarm/cloudflared-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cloudflared-0.0.4.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cloudflared-0.0.4.tgz
     version: 0.0.4
   - annotations:
       application.giantswarm.io/metadata: https://giantswarm.github.io/giantswarm-catalog/cloudflared-0.0.3.tgz-meta/main.yaml
@@ -869,7 +869,7 @@ entries:
     sources:
     - https://github.com/giantswarm/cloudflared-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/cloudflared-0.0.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/cloudflared-0.0.3.tgz
     version: 0.0.3
   efk-stack-app:
   - annotations:
@@ -922,7 +922,7 @@ entries:
     sources:
     - https://github.com/giantswarm/efk-stack-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.4.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.4.1.tgz
     version: 0.4.1
   - apiVersion: v1
     appVersion: 0.4.0
@@ -938,7 +938,7 @@ entries:
     sources:
     - https://github.com/giantswarm/efk-stack-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.4.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.4.0.tgz
     version: 0.4.0
   - annotations:
       application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/efk-stack-app/v0.3.6/helm/efk-stack-app/values.schema.json
@@ -957,7 +957,7 @@ entries:
     - https://github.com/giantswarm/efk-stack-app
     - https://raw.githubusercontent.com/giantswarm/efk-stack-app/v0.3.6/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.3.6.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.3.6.tgz
     version: 0.3.6
   - annotations:
       application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/efk-stack-app/v0.3.5/helm/efk-stack-app/values.schema.json
@@ -976,7 +976,7 @@ entries:
     - https://github.com/giantswarm/efk-stack-app
     - https://raw.githubusercontent.com/giantswarm/efk-stack-app/v0.3.5/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.3.5.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.3.5.tgz
     version: 0.3.5
   - annotations:
       application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/efk-stack-app/v0.3.4/helm/efk-stack-app/values.schema.json
@@ -995,7 +995,7 @@ entries:
     - https://github.com/giantswarm/efk-stack-app
     - https://raw.githubusercontent.com/giantswarm/efk-stack-app/v0.3.4/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.3.4.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.3.4.tgz
     version: 0.3.4
   - apiVersion: v1
     appVersion: 1.9.0
@@ -1012,7 +1012,7 @@ entries:
     - https://github.com/giantswarm/efk-stack-app
     - https://raw.githubusercontent.com/giantswarm/efk-stack-app/v0.3.3/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.3.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.3.3.tgz
     version: 0.3.3
   - apiVersion: v1
     appVersion: 1.9.0
@@ -1029,7 +1029,7 @@ entries:
     - https://github.com/giantswarm/efk-stack-app
     - https://raw.githubusercontent.com/giantswarm/efk-stack-app/v0.3.2/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.3.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.3.2.tgz
     version: 0.3.2
   - apiVersion: v1
     appVersion: 1.9.0
@@ -1046,7 +1046,7 @@ entries:
     - https://github.com/giantswarm/efk-stack-app
     - https://raw.githubusercontent.com/giantswarm/efk-stack-app/v0.3.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.3.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.3.1.tgz
     version: 0.3.1
   - apiVersion: v1
     appVersion: 1.9.0
@@ -1063,7 +1063,7 @@ entries:
     - https://github.com/giantswarm/efk-stack-app
     - https://raw.githubusercontent.com/giantswarm/efk-stack-app/v0.3.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
     appVersion: 1.3.0
@@ -1079,7 +1079,7 @@ entries:
     sources:
     - https://github.com/giantswarm/efk-stack-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
     appVersion: 1.3.0
@@ -1094,7 +1094,7 @@ entries:
     sources:
     - https://github.com/giantswarm/efk-stack-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.1.5.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.1.5.tgz
     version: 0.1.5
   - apiVersion: v1
     appVersion: 1.3.0
@@ -1109,7 +1109,7 @@ entries:
     sources:
     - https://github.com/giantswarm/efk-stack-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.1.4.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.1.4.tgz
     version: 0.1.4
   - apiVersion: v1
     appVersion: 1.3.0
@@ -1124,7 +1124,7 @@ entries:
     sources:
     - https://github.com/giantswarm/efk-stack-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/efk-stack-app-0.1.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/efk-stack-app-0.1.3.tgz
     version: 0.1.3
   external-dns-app:
   - annotations:
@@ -1210,7 +1210,7 @@ entries:
     sources:
     - https://github.com/kubernetes-sigs/external-dns
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/external-dns-app-2.1.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/external-dns-app-2.1.1.tgz
     version: 2.1.1
   - annotations:
       application.giantswarm.io/metadata: https://giantswarm.github.io/giantswarm-catalog/external-dns-app-2.1.0.tgz-meta/main.yaml
@@ -1227,7 +1227,7 @@ entries:
     sources:
     - https://github.com/kubernetes-sigs/external-dns
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/external-dns-app-2.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/external-dns-app-2.1.0.tgz
     version: 2.1.0
   - annotations:
       application.giantswarm.io/metadata: https://giantswarm.github.io/giantswarm-catalog/external-dns-app-2.0.2.tgz-meta/main.yaml
@@ -1244,7 +1244,7 @@ entries:
     sources:
     - https://github.com/kubernetes-sigs/external-dns
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/external-dns-app-2.0.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/external-dns-app-2.0.2.tgz
     version: 2.0.2
   - annotations:
       application.giantswarm.io/metadata: https://giantswarm.github.io/giantswarm-catalog/external-dns-app-2.0.1.tgz-meta/main.yaml
@@ -1261,7 +1261,7 @@ entries:
     sources:
     - https://github.com/kubernetes-sigs/external-dns
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/external-dns-app-2.0.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/external-dns-app-2.0.1.tgz
     version: 2.0.1
   - annotations:
       application.giantswarm.io/metadata: https://giantswarm.github.io/giantswarm-catalog/external-dns-app-2.0.0.tgz-meta/main.yaml
@@ -1277,7 +1277,7 @@ entries:
     sources:
     - https://github.com/kubernetes-sigs/external-dns
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/external-dns-app-2.0.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/external-dns-app-2.0.0.tgz
     version: 2.0.0
   fluent-logshipping-app:
   - apiVersion: v1
@@ -1393,7 +1393,7 @@ entries:
     - https://github.com/giantswarm/grafana-app
     - https://github.com/grafana/grafana
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/grafana-app-0.1.0-alpha1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/grafana-app-0.1.0-alpha1.tgz
     version: 0.1.0-alpha1
   kong-app:
   - annotations:
@@ -1467,7 +1467,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/kong-app/v1.1.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/kong-app-1.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/kong-app-1.1.0.tgz
     version: 1.1.0
   - apiVersion: v1
     appVersion: "2.1"
@@ -1490,7 +1490,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/kong-app/v1.0.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/kong-app-1.0.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/kong-app-1.0.0.tgz
     version: 1.0.0
   - apiVersion: v1
     appVersion: 2.1.3
@@ -1508,7 +1508,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/kong-app/v0.9.2/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/kong-app-0.9.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/kong-app-0.9.2.tgz
     version: 0.9.2
   - apiVersion: v1
     appVersion: 2.1.3
@@ -1526,7 +1526,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/kong-app/v0.9.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/kong-app-0.9.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/kong-app-0.9.1.tgz
     version: 0.9.1
   - apiVersion: v1
     appVersion: 2.1.3
@@ -1544,7 +1544,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/kong-app/v0.9.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/kong-app-0.9.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/kong-app-0.9.0.tgz
     version: 0.9.0
   - apiVersion: v1
     appVersion: 2.0.4
@@ -1558,7 +1558,7 @@ entries:
     - https://github.com/Kong/kong
     - https://raw.githubusercontent.com/giantswarm/kong-app/v0.8.3/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/kong-app-0.8.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/kong-app-0.8.3.tgz
     version: 0.8.3
   - apiVersion: v1
     appVersion: 2.0.4
@@ -1572,7 +1572,7 @@ entries:
     - https://github.com/Kong/kong
     - https://raw.githubusercontent.com/giantswarm/kong-app/v0.8.2/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/kong-app-0.8.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/kong-app-0.8.2.tgz
     version: 0.8.2
   - apiVersion: v1
     appVersion: 2.0.4
@@ -1586,7 +1586,7 @@ entries:
     - https://github.com/Kong/kong
     - https://raw.githubusercontent.com/giantswarm/kong-app/v0.8.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/kong-app-0.8.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/kong-app-0.8.1.tgz
     version: 0.8.1
   - apiVersion: v1
     appVersion: 2.0.4
@@ -1600,7 +1600,7 @@ entries:
     - https://github.com/Kong/kong
     - https://raw.githubusercontent.com/giantswarm/kong-app/v0.8.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/kong-app-0.8.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/kong-app-0.8.0.tgz
     version: 0.8.0
   - apiVersion: v1
     appVersion: 2.0.1
@@ -1613,7 +1613,7 @@ entries:
     sources:
     - https://github.com/Kong/kong
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/kong-app-0.7.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/kong-app-0.7.2.tgz
     version: 0.7.2
   - apiVersion: v1
     appVersion: 2.0.1
@@ -1626,7 +1626,7 @@ entries:
     sources:
     - https://github.com/Kong/kong
     urls:
-    - https://giantswarm.github.com/giantswarm-incubator-catalog/kong-app-0.7.1.tgz
+    - https://giantswarm.github.io/giantswarm-incubator-catalog/kong-app-0.7.1.tgz
     version: 0.7.1
   loki:
   - annotations:
@@ -1734,7 +1734,7 @@ entries:
     - https://github.com/giantswarm/loki-app
     type: application
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/loki-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/loki-0.1.0.tgz
     version: 0.1.0
   - annotations:
       application.giantswarm.io/metadata: https://giantswarm.github.io/giantswarm-catalog/loki-0.1.0-alpha.tgz-meta/main.yaml
@@ -1760,7 +1760,7 @@ entries:
     - https://github.com/giantswarm/loki-app
     type: application
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/loki-0.1.0-alpha.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/loki-0.1.0-alpha.tgz
     version: 0.1.0-alpha
   nginx-ingress-controller-app:
   - annotations:
@@ -1809,7 +1809,7 @@ entries:
     kubeVersion: '>=1.16.0-0'
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.14.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.14.1.tgz
     version: 1.14.1
   - annotations:
       application.giantswarm.io/metadata: https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.14.0.tgz-meta/main.yaml
@@ -1825,7 +1825,7 @@ entries:
     kubeVersion: '>=1.16.0-0'
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.14.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.14.0.tgz
     version: 1.14.0
   - annotations:
       application.giantswarm.io/metadata: https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.13.0.tgz-meta/main.yaml
@@ -1841,7 +1841,7 @@ entries:
     kubeVersion: '>=1.16.0-0'
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.13.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.13.0.tgz
     version: 1.13.0
   - annotations:
       application.giantswarm.io/metadata: https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.12.0.tgz-meta/main.yaml
@@ -1857,7 +1857,7 @@ entries:
     kubeVersion: '>=1.16.0-0'
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.12.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.12.0.tgz
     version: 1.12.0
   - apiVersion: v1
     appVersion: v0.41.2
@@ -1871,7 +1871,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.11.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.11.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.11.0.tgz
     version: 1.11.0
   - apiVersion: v1
     appVersion: v0.40.2
@@ -1885,7 +1885,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.10.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.10.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.10.0.tgz
     version: 1.10.0
   - apiVersion: v1
     appVersion: v0.35.0
@@ -1898,7 +1898,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.9.2/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.9.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.9.2.tgz
     version: 1.9.2
   - apiVersion: v1
     appVersion: v0.34.1
@@ -1911,7 +1911,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.9.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.9.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.9.1.tgz
     version: 1.9.1
   - apiVersion: v1
     appVersion: v0.34.1
@@ -1924,7 +1924,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.9.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.9.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.9.0.tgz
     version: 1.9.0
   - apiVersion: v1
     appVersion: v0.34.1
@@ -1937,7 +1937,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.8.4/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.8.4.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.8.4.tgz
     version: 1.8.4
   - apiVersion: v1
     appVersion: v0.34.1
@@ -1950,7 +1950,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.8.3/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.8.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.8.3.tgz
     version: 1.8.3
   - apiVersion: v1
     appVersion: v0.34.1
@@ -1963,7 +1963,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.8.2/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.8.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.8.2.tgz
     version: 1.8.2
   - apiVersion: v1
     appVersion: v0.34.1
@@ -1976,7 +1976,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.8.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.8.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.8.1.tgz
     version: 1.8.1
   - apiVersion: v1
     appVersion: v0.34.1
@@ -1989,7 +1989,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.8.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.8.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.8.0.tgz
     version: 1.8.0
   - apiVersion: v1
     appVersion: v0.34.1
@@ -2002,7 +2002,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.7.3/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.7.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.7.3.tgz
     version: 1.7.3
   - apiVersion: v1
     appVersion: v0.34.0
@@ -2015,7 +2015,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.7.2/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.7.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.7.2.tgz
     version: 1.7.2
   - apiVersion: v1
     appVersion: v0.33.0
@@ -2028,7 +2028,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.7.1/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.7.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.7.1.tgz
     version: 1.7.1
   - apiVersion: v1
     appVersion: v0.33.0
@@ -2041,7 +2041,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.7.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.7.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.7.0.tgz
     version: 1.7.0
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2054,7 +2054,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.6.12/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.12.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.12.tgz
     version: 1.6.12
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2067,7 +2067,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.6.11/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.11.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.11.tgz
     version: 1.6.11
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2080,7 +2080,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.6.10/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.10.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.10.tgz
     version: 1.6.10
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2093,7 +2093,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/v1.6.9/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.9.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.9.tgz
     version: 1.6.9
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2106,7 +2106,7 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/nginx-ingress-controller-app/1.6.8/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.8.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.8.tgz
     version: 1.6.8
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2117,7 +2117,7 @@ entries:
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.7.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.7.tgz
     version: 1.6.7
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2128,7 +2128,7 @@ entries:
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.6.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.6.tgz
     version: 1.6.6
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2139,7 +2139,7 @@ entries:
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.5.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.5.tgz
     version: 1.6.5
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2150,7 +2150,7 @@ entries:
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.4.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.4.tgz
     version: 1.6.4
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2161,7 +2161,7 @@ entries:
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.3.tgz
     version: 1.6.3
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2172,7 +2172,7 @@ entries:
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.2.tgz
     version: 1.6.2
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2183,7 +2183,7 @@ entries:
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.1.tgz
     version: 1.6.1
   - apiVersion: v1
     appVersion: v0.30.0
@@ -2194,7 +2194,7 @@ entries:
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.6.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.6.0.tgz
     version: 1.6.0
   - apiVersion: v1
     appVersion: v0.29.0
@@ -2204,7 +2204,7 @@ entries:
     home: https://github.com/giantswarm/nginx-ingress-controller-app
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.5.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.5.0.tgz
     version: 1.5.0
   - apiVersion: v1
     appVersion: v0.28.0
@@ -2214,7 +2214,7 @@ entries:
     home: https://github.com/giantswarm/nginx-ingress-controller-app
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.4.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.4.0.tgz
     version: 1.4.0
   - apiVersion: v1
     appVersion: v0.27.1
@@ -2224,7 +2224,7 @@ entries:
     home: https://github.com/giantswarm/nginx-ingress-controller-app
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.3.0.tgz
     version: 1.3.0
   - apiVersion: v1
     appVersion: v0.27.1
@@ -2234,7 +2234,7 @@ entries:
     home: https://github.com/giantswarm/nginx-ingress-controller-app
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.2.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.2.1.tgz
     version: 1.2.1
   - apiVersion: v1
     appVersion: v0.27.1
@@ -2244,7 +2244,7 @@ entries:
     home: https://github.com/giantswarm/nginx-ingress-controller-app
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.2.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.2.0.tgz
     version: 1.2.0
   - apiVersion: v1
     appVersion: v0.26.1
@@ -2254,7 +2254,7 @@ entries:
     home: https://github.com/giantswarm/nginx-ingress-controller-app
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.1.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.1.1.tgz
     version: 1.1.1
   - apiVersion: v1
     appVersion: v0.26.1
@@ -2264,7 +2264,7 @@ entries:
     home: https://github.com/giantswarm/nginx-ingress-controller-app
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-1.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-1.1.0.tgz
     version: 1.1.0
   - apiVersion: v1
     appVersion: v0.25.1
@@ -2274,7 +2274,7 @@ entries:
     home: https://github.com/giantswarm/nginx-ingress-controller-app
     name: nginx-ingress-controller-app
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/nginx-ingress-controller-app-0.12.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/nginx-ingress-controller-app-0.12.0.tgz
     version: 0.12.0
   prometheus-operator-app:
   - annotations:
@@ -2381,7 +2381,7 @@ entries:
     - https://github.com/prometheus-community/helm-charts
     - https://github.com/prometheus-operator/kube-prometheus
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/prometheus-operator-app-0.6.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/prometheus-operator-app-0.6.0.tgz
     version: 0.6.0
   - annotations:
       application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/prometheus-operator-app/v0.5.2/helm/prometheus-operator-app/values.schema.json
@@ -2433,7 +2433,7 @@ entries:
     - https://github.com/prometheus-community/helm-charts
     - https://github.com/prometheus-operator/kube-prometheus
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/prometheus-operator-app-0.5.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/prometheus-operator-app-0.5.2.tgz
     version: 0.5.2
   - annotations:
       application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/prometheus-operator-app/v0.5.1/helm/prometheus-operator-app/values.schema.json
@@ -2485,7 +2485,7 @@ entries:
     - https://github.com/prometheus-community/helm-charts
     - https://github.com/prometheus-operator/kube-prometheus
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/prometheus-operator-app-0.5.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/prometheus-operator-app-0.5.1.tgz
     version: 0.5.1
   - annotations:
       application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/prometheus-operator-app/v0.5.0/helm/prometheus-operator-app/values.schema.json
@@ -2537,7 +2537,7 @@ entries:
     - https://github.com/prometheus-community/helm-charts
     - https://github.com/prometheus-operator/kube-prometheus
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/prometheus-operator-app-0.5.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/prometheus-operator-app-0.5.0.tgz
     version: 0.5.0
   - annotations:
       artifacthub.io/links: |
@@ -2588,7 +2588,7 @@ entries:
     - https://github.com/prometheus-community/helm-charts
     - https://github.com/prometheus-operator/kube-prometheus
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/prometheus-operator-app-0.4.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/prometheus-operator-app-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
     appVersion: 0.38.1
@@ -2620,7 +2620,7 @@ entries:
     - https://github.com/coreos/prometheus-operator
     - https://coreos.com/operators/prometheus
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/prometheus-operator-app-0.3.4.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/prometheus-operator-app-0.3.4.tgz
     version: 0.3.4
   - apiVersion: v1
     appVersion: v0.38.1
@@ -2639,7 +2639,7 @@ entries:
     - https://github.com/coreos/prometheus-operator
     - https://coreos.com/operators/prometheus
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/prometheus-operator-app-0.3.3.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/prometheus-operator-app-0.3.3.tgz
     version: 0.3.3
   - apiVersion: v1
     appVersion: v0.38.1
@@ -2655,7 +2655,7 @@ entries:
     - https://github.com/coreos/prometheus-operator
     - https://coreos.com/operators/prometheus
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/prometheus-operator-app-0.3.2.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/prometheus-operator-app-0.3.2.tgz
     version: 0.3.2
   - apiVersion: v1
     appVersion: v0.38.1
@@ -2671,7 +2671,7 @@ entries:
     - https://github.com/coreos/prometheus-operator
     - https://coreos.com/operators/prometheus
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/prometheus-operator-app-0.3.1.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/prometheus-operator-app-0.3.1.tgz
     version: 0.3.1
   - apiVersion: v1
     appVersion: v0.38.1
@@ -2687,7 +2687,7 @@ entries:
     - https://github.com/coreos/prometheus-operator
     - https://coreos.com/operators/prometheus
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/prometheus-operator-app-0.3.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/prometheus-operator-app-0.3.0.tgz
     version: 0.3.0
   promtail:
   - annotations:
@@ -2803,7 +2803,7 @@ entries:
     - https://github.com/giantswarm/promtail-app
     type: application
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/promtail-0.1.0-alpha.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/promtail-0.1.0-alpha.tgz
     version: 0.1.0-alpha
   strimzi-kafka-operator-app:
   - apiVersion: v1
@@ -2872,6 +2872,6 @@ entries:
     sources:
     - https://raw.githubusercontent.com/giantswarm/strimzi-kafka-operator-app/v0.1.0/README.md
     urls:
-    - https://giantswarm.github.com/giantswarm-catalog/strimzi-kafka-operator-app-0.1.0.tgz
+    - https://giantswarm.github.io/giantswarm-catalog/strimzi-kafka-operator-app-0.1.0.tgz
     version: 0.1.0
 generated: "2021-04-06T16:19:41.788457592Z"


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898