### PR TITLE
Removes old AWS account ID

### DIFF
--- a/loki-0.1.0-alpha.tgz-meta/README.md
+++ b/loki-0.1.0-alpha.tgz-meta/README.md
@@ -82,7 +82,7 @@ AWS account.
                 {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:aws:iam::180547736195:role/m2h60-IAMManager-Role"
+                    "AWS": "arn:aws:iam::123456789012:role/xxxxx-IAMManager-Role"
                 },
                 "Action": "sts:AssumeRole"
                 }

--- a/loki-0.1.0.tgz-meta/README.md
+++ b/loki-0.1.0.tgz-meta/README.md
@@ -82,7 +82,7 @@ AWS account.
                 {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:aws:iam::180547736195:role/m2h60-IAMManager-Role"
+                    "AWS": "arn:aws:iam::123456789012:role/xxxxx-IAMManager-Role"
                 },
                 "Action": "sts:AssumeRole"
                 }

--- a/loki-0.1.1-alpha.tgz-meta/README.md
+++ b/loki-0.1.1-alpha.tgz-meta/README.md
@@ -82,7 +82,7 @@ AWS account.
                 {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:aws:iam::180547736195:role/m2h60-IAMManager-Role"
+                    "AWS": "arn:aws:iam::123456789012:role/xxxxx-IAMManager-Role"
                 },
                 "Action": "sts:AssumeRole"
                 }

--- a/loki-0.1.1-alpha2.tgz-meta/README.md
+++ b/loki-0.1.1-alpha2.tgz-meta/README.md
@@ -82,7 +82,7 @@ AWS account.
                 {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:aws:iam::180547736195:role/m2h60-IAMManager-Role"
+                    "AWS": "arn:aws:iam::123456789012:role/xxxxx-IAMManager-Role"
                 },
                 "Action": "sts:AssumeRole"
                 }

--- a/loki-0.1.2-beta.tgz-meta/README.md
+++ b/loki-0.1.2-beta.tgz-meta/README.md
@@ -82,7 +82,7 @@ AWS account.
                 {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:aws:iam::180547736195:role/m2h60-IAMManager-Role"
+                    "AWS": "arn:aws:iam::123456789012:role/xxxxx-IAMManager-Role"
                 },
                 "Action": "sts:AssumeRole"
                 }

--- a/loki-0.2.0.tgz-meta/README.md
+++ b/loki-0.2.0.tgz-meta/README.md
@@ -82,7 +82,7 @@ AWS account.
                 {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:aws:iam::180547736195:role/m2h60-IAMManager-Role"
+                    "AWS": "arn:aws:iam::123456789012:role/xxxxx-IAMManager-Role"
                 },
                 "Action": "sts:AssumeRole"
                 }

--- a/loki-0.3.0.tgz-meta/README.md
+++ b/loki-0.3.0.tgz-meta/README.md
@@ -87,7 +87,7 @@ AWS account.
                 {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:aws:iam::180547736195:role/m2h60-IAMManager-Role"
+                    "AWS": "arn:aws:iam::123456789012:role/xxxxx-IAMManager-Role"
                 },
                 "Action": "sts:AssumeRole"
                 }

--- a/loki-0.3.1.tgz-meta/README.md
+++ b/loki-0.3.1.tgz-meta/README.md
@@ -87,7 +87,7 @@ AWS account.
                 {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:aws:iam::180547736195:role/m2h60-IAMManager-Role"
+                    "AWS": "arn:aws:iam::123456789012:role/xxxxx-IAMManager-Role"
                 },
                 "Action": "sts:AssumeRole"
                 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30644

Removes old AWS account ID (mainly so it doesn't appear in search and annoy me anymore).